### PR TITLE
Switch to Node.js v4.x installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - \
  && apt-get -q update                                           \
  && apt-get -y -qq upgrade                                      \
  && apt-get -y -qq install                                      \
-        nodejs                                                  \
+        nodejs build-essential                                  \
  && apt-get clean
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ RUN /usr/local/sbin/builder-enter
 
 
 # Install packages
-RUN curl -sL https://deb.nodesource.com/setup | sudo bash - \
- && apt-get -q update                                       \
- && apt-get -y -qq upgrade                                  \
- && apt-get -y -qq install                                  \
-        nodejs                                              \
+RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - \
+ && apt-get -q update                                           \
+ && apt-get -y -qq upgrade                                      \
+ && apt-get -y -qq install                                      \
+        nodejs                                                  \
  && apt-get clean
 
 


### PR DESCRIPTION
Also added build-essential to the list of installed packages. Lots of modules on npm need building during installation so I can't see any reason not to include this by default.

Closes #3 